### PR TITLE
Add alternative Chan version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 .idea/
 .directory
+**/tags
 
 haskring/.stack-work/
 haskring/stack.yaml.lock
+haskring/.ghc.environment*
+haskring/dist-newstyle
 
 ring

--- a/haskring/HaskRing.cabal
+++ b/haskring/HaskRing.cabal
@@ -20,5 +20,6 @@ executable haskring
                        optparse-applicative,
                        time,
                        vector
-  ghc-options:         -O3 -Wall 
+  ghc-options:         -O2 -Wall -threaded -rtsopts -with-rtsopts=-N
+
 

--- a/haskring/src/Main.hs
+++ b/haskring/src/Main.hs
@@ -17,7 +17,7 @@ import Data.Version (showVersion)
 import Data.Time.Clock 
 import qualified Data.Vector as V
 
-data ThreadContext = ThreadContext {
+data ThreadContext a = ThreadContext {
       threadIndex :: {-# UNPACK #-} !Int
     -- ^ The index of this thread in the ring. The parent index can be 
     -- trivially calculated.
@@ -25,21 +25,21 @@ data ThreadContext = ThreadContext {
     -- ^ The total nodes in the ring.
     , totalTrips :: {-# UNPACK #-} !Int
     -- ^ The number of times each message needs to be passed around.
-    , mailbox :: Chan ()
+    , mailbox :: Chan a
     -- ^ The mailbox for this thread.
     }
 
-newtype Ring = Ring { getRing :: V.Vector ThreadContext }
+newtype Ring a = Ring { getRing :: V.Vector (ThreadContext a) }
 
-neighbourIndex :: ThreadContext -> Int
+neighbourIndex :: ThreadContext a -> Int
 neighbourIndex ThreadContext{..}
   | threadIndex == totalNodes - 1 = 0
   | otherwise = succ threadIndex
 {-# INLINE neighbourIndex #-}
 
-sendMessage :: Ring -> Int -> IO ()
-sendMessage (Ring ring) threadIndex =
-    writeChan (mailbox $ ring V.! threadIndex) ()
+sendMessage :: Ring a -> Int -> a -> IO ()
+sendMessage (Ring ring) threadIndex msg =
+    writeChan (mailbox $ ring V.! threadIndex) msg
 {-# INLINE sendMessage #-}
 
 main :: IO ()
@@ -57,7 +57,7 @@ mainRun opts@Options{..} = do
 
   -- We can already deliver the message to threadIndex = 0, as the mailbox
   -- already exist.
-  forM_ [1 .. trips] $ \_ -> sendMessage ring 0
+  forM_ [1 .. trips] $ \t -> sendMessage ring 0 t
 
   let lastThread = getRing ring V.! (nodes - 1)
   lastThreadMailbox <- dupChan (mailbox lastThread)
@@ -65,14 +65,18 @@ mainRun opts@Options{..} = do
   forM_ (getRing ring) $ \ctx -> spinUpThread ctx ring
 
   -- Wait for messages on the last element of the ring.
-  forM_ [1 .. trips] $ \_ -> readChan lastThreadMailbox
+  x <- last <$> (forM [1 .. trips] $ \_ -> readChan lastThreadMailbox)
 
   messageExchangeEnded <- getCurrentTime
 
   let t0 :: Int = round (1000 * (setupEnded `diffUTCTime` setupStarted))
   let t1 :: Int = round (1000 * (messageExchangeEnded `diffUTCTime` setupEnded))
 
-  putStrLn $ show t0 <> " " <> show t1 <> " " <> show nodes <> " " <> show trips
+  -- Sanity check.
+  if x == trips 
+     then putStrLn $ show t0 <> " " <> show t1 <> " " <> show nodes <> " " <> show trips
+     else error "Ring failed."
+
 
 mainRunUnbuff :: Options -> IO ()
 mainRunUnbuff Options{..} = do
@@ -95,7 +99,7 @@ node' s d = do
   node' s d
 
 -- | Creates a new 'Ring' from some 'Options'.
-newRing :: Options -> IO Ring
+newRing :: Options -> IO (Ring a)
 newRing Options{..} = Ring . V.fromList <$> (
     forM [0 .. nodes - 1] $ \nodeIndex -> do
         myMailbox       <- newChan
@@ -105,21 +109,20 @@ newRing Options{..} = Ring . V.fromList <$> (
                            , mailbox       = myMailbox
                            })
 
-spinUpThread :: ThreadContext -> Ring -> IO ThreadId
+spinUpThread :: ThreadContext a -> Ring a -> IO ThreadId
 spinUpThread ctx@ThreadContext{..} ring = forkIO loop
   where
       loop :: IO ()
       loop = do
-          () <- readChan mailbox
-          sendMessage ring (neighbourIndex ctx)
+          msg <- readChan mailbox
+          sendMessage ring (neighbourIndex ctx) msg
           loop
-
 
 createRingUnbuff :: Int -> IO (MVar Int, MVar Int)
 createRingUnbuff n = do
    chans :: V.Vector (MVar Int) <- V.generateM (n+1) $ const newEmptyMVar
 
-   forM_ [0..n-1] $ \i -> forkIO (forever $ takeMVar (chans ! i) >>= putMVar (chans ! (i+1)))
+   forM_ [0..n-1] $ \i -> forkIO (forever $ takeMVar (chans V.! i) >>= putMVar (chans V.! (i+1)))
 
    return (V.head chans, V.last chans)
 


### PR DESCRIPTION
This adds an alternative Haskell version based on `Chan`, like the original one, but with the control flow rewritten. It might just be that I am doing something silly on my implementation, but this seems to perform in the same league of the `go` version (usually the `go` version is slightly faster).