### PR TITLE
:timer.tc for benchmarking

### DIFF
--- a/exring/lib/cli.ex
+++ b/exring/lib/cli.ex
@@ -3,10 +3,20 @@ defmodule ExRing.CLI do
     ExRing.start(
       String.to_integer(n),
       String.to_integer(m)
-    )
+    ) |> print_times(n, m, :millisecond)
   end
 
   def main(_args) do
     IO.puts("./exring N M")
+  end
+
+  defp print_times({creation_time, run_time}, n, m, :millisecond) do
+    IO.puts("#{to_ms_string(creation_time)} #{to_ms_string(run_time)} #{n} #{m}")
+  end
+
+  def to_ms_string(time_micro) do
+    time_micro/1_000
+    |> Float.round()
+    |> :erlang.float_to_binary(decimals: 0)
   end
 end

--- a/exring/lib/exring.ex
+++ b/exring/lib/exring.ex
@@ -4,13 +4,9 @@ defmodule ExRing do
   """
 
   def start(n, m) do
-    t0 = Time.utc_now()
-
-    {creation_time, ring} = create_ring(n)
-    run(ring, m)
-
-    t1 = Time.utc_now()
-    IO.puts("#{creation_time} #{Time.diff(t1, t0, :millisecond)} #{n} #{m}")
+    {creation_time, ring} = :timer.tc(__MODULE__, :create_ring, [n])
+    {run_time, 0} = :timer.tc(__MODULE__, :run, [ring, m])
+    {creation_time, run_time}
   end
 
   def run(_ring, 0), do: 0
@@ -21,13 +17,8 @@ defmodule ExRing do
     end
   end
 
-  @spec create_ring(number) :: {number, pid}
-  def create_ring(n) do
-    t0 = Time.utc_now()
-    ring = chain(self(), n)
-    t1 = Time.utc_now()
-    {Time.diff(t1, t0, :millisecond), ring}
-  end
+  @spec create_ring(number) :: pid
+  def create_ring(n), do: chain(self(), n)
 
 
   #******************* HELPERS *******************


### PR DESCRIPTION
I made some changes benchmarking the functions with [:timer.tc/3](http://erlang.org/doc/man/timer.html#tc-3) which uses `monotonic_time/0`. 

I've then refactored the code making the benchmarks outside the tested functions.

Instead of printing the result, the `ExRing.start/2` now returns a `{created_time, run_time}` (times in **micro**seconds) to `ExRing.CLI.main/2`. I've also added two functions in `ExRing.CLI.main/2`:
* `to_ms_string/2` which converts the time from microsecond (integer) to the millisecond  string representation
* `print_times/4` prints the result